### PR TITLE
drawer tab highlight match URL regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/NUS-ALSET/achievements.svg)](http://isitmaintained.com/project/NUS-ALSET/achievements "Percentage of issues still open")
 
 **An integrated web application for learning and teaching programming:computer:**
-@[https://achievements-dev.firebaseapp.com/](https://achievements-dev.firebaseapp.com/#/home)
+@[https://achievements-dev.firebaseapp.com/](https://achievements-dev.firebaseapp.com/#/)
 
 ***
 

--- a/src/components/AppDrawerElements.js
+++ b/src/components/AppDrawerElements.js
@@ -50,21 +50,22 @@ const AppDrawerElements = (onRequestClose, userId, isAdmin, location, classes) =
       >
         <ListItem>
           <ListItemIcon>
-            {("/" === location.pathname)
+            {("/" === location.pathname || "/home" === location.pathname)
             ? <Whatshot style={{fill: "red"}} />
             : <Whatshot />}
           </ListItemIcon>
           <ListItemText primary="Home" />
         </ListItem>
       </MenuItem>
+      {/* the Paths tab will be highlighted if URL starts with "/paths" */}
       <MenuItem
         component={Link}
         to="/paths"
-        selected={"/paths" === location.pathname}
+        selected={location.pathname.match(/\/paths/)}
       >
         <ListItem>
           <ListItemIcon>
-          {("/paths" === location.pathname)
+          {location.pathname.match(/\/paths/)
             ? <Explore style={{fill: "red"}} />
             : <Explore />}
           </ListItemIcon>
@@ -82,28 +83,30 @@ const AppDrawerElements = (onRequestClose, userId, isAdmin, location, classes) =
         </ListSubheader>}
       onClick={onRequestClose}
     >
+      {/* the Courses tab will be highlighted if URL starts with "/courses" */}
       <MenuItem
         component={Link}
         to="/courses"
-        selected={"/courses" === location.pathname}
+        selected={location.pathname.match(/\/courses/)}
       >
         <ListItem>
           <ListItemIcon>
-          {("/courses" === location.pathname)
+          {location.pathname.match(/\/courses/)
             ? <Group style={{fill: "red"}} />
             : <Group />}
           </ListItemIcon>
           <ListItemText primary="Courses" />
         </ListItem>
       </MenuItem>
+      {/* the Cohorts tab will be highlighted if URL starts with "/cohorts" */}
       <MenuItem
         component={Link}
         to="/cohorts"
-        selected={"/cohorts" === location.pathname}
+        selected={location.pathname.match(/\/cohorts/)}
       >
         <ListItem>
           <ListItemIcon>
-          {("/cohorts" === location.pathname)
+          {location.pathname.match(/\/cohorts/)
             ? <Domain style={{fill: "red"}} />
             : <Domain />}
           </ListItemIcon>
@@ -115,16 +118,15 @@ const AppDrawerElements = (onRequestClose, userId, isAdmin, location, classes) =
     <Divider />
 
     <MenuList onClick={onRequestClose}>
+      {/* the Profile tab will be highlighted if URL starts with "/profile" */}
       <MenuItem
         component={Link}
         to={`/profile/${userId || "non-logged"}`}
-        selected={
-          `/profile/${userId || "non-logged"}` === location.pathname
-        }
+        selected={location.pathname.match(/\/profile/)}
       >
         <ListItem>
           <ListItemIcon>
-          {(`/profile/${userId || "non-logged"}` === location.pathname)
+          {location.pathname.match(/\/profile/)
             ? <Mood style={{fill: "red"}} />
             : <Mood />}
           </ListItemIcon>


### PR DESCRIPTION
**Fix:**
the drawer tab was not highlighted when URL is at path activities or course assignments.
Now the tab is highlighted according to the URL regex:
![image](https://user-images.githubusercontent.com/26617036/44379106-0924ef80-a537-11e8-966f-9fb13db0b4c5.png)
