### PR TITLE
 AddTextSolutionDialog for Team/Text solutions Regex detection

### DIFF
--- a/src/components/dialogs/AddTextSolutionDialog.js
+++ b/src/components/dialogs/AddTextSolutionDialog.js
@@ -44,6 +44,7 @@ class AddTextSolutionDialog extends React.PureComponent {
     // or has only empty spaces =>
     // disable the commit button
     // Regex from Olafs Vandans
+    /* eslint-disable no-useless-escape */
     if (/^[^\s][a-zA-Z0-9\t\n ./<>?;:"'`!@#$%^&*()\[\]{}_+=|\\-]*$/
       .test(event.target.value)
     ) {
@@ -75,7 +76,7 @@ class AddTextSolutionDialog extends React.PureComponent {
             defaultValue={(solution && solution.value) || ""}
             helperText={this.state.isCorrectInput
               ? ""
-              : "input cannot be empty and should has only valid characters"}
+              : "input should not be empty or have invalid characters"}
             fullWidth
             label="Solution"
             onChange={this.onChangeSolution}

--- a/src/components/dialogs/AddTextSolutionDialog.js
+++ b/src/components/dialogs/AddTextSolutionDialog.js
@@ -14,6 +14,13 @@ import PropTypes from "prop-types";
 import React from "react";
 import TextField from "@material-ui/core/TextField";
 
+/* AddTextSolutionDialog is currently used for:
+ * ASSIGNMENTS_TYPES.TeamFormation.id,
+ * ASSIGNMENTS_TYPES.TeamText.id,
+ * ASSIGNMENTS_TYPES.Text.id
+ * so only allow for printable characters as input
+ */
+
 class AddTextSolutionDialog extends React.PureComponent {
   static propTypes = {
     onClose: PropTypes.func.isRequired,
@@ -25,13 +32,30 @@ class AddTextSolutionDialog extends React.PureComponent {
   };
 
   state = {
-    solution: ""
+    solution: "",
+    // detect if text input is only printable characters,
+    // if so CorrentInput
+    isCorrectInput: true,
   };
 
   onChangeSolution = event => {
-    this.setState({
-      solution: event.target.value
-    });
+    // if text input has non-keyboard characters,
+    // or start with empty space,
+    // or has only empty spaces =>
+    // disable the commit button
+    // Regex from Olafs Vandans
+    if (/^[^\s][a-zA-Z0-9\t\n ./<>?;:"'`!@#$%^&*()\[\]{}_+=|\\-]*$/
+      .test(event.target.value)
+    ) {
+      this.setState({
+        isCorrectInput: true,
+        solution: event.target.value,
+      });
+    } else {
+      this.setState({
+        isCorrectInput: false
+      });
+    }
   };
 
   catchReturn = event =>
@@ -47,7 +71,11 @@ class AddTextSolutionDialog extends React.PureComponent {
         <DialogContent>
           <TextField
             autoFocus
+            error={!this.state.isCorrectInput}
             defaultValue={(solution && solution.value) || ""}
+            helperText={this.state.isCorrectInput
+              ? ""
+              : "input cannot be empty and should has only valid characters"}
             fullWidth
             label="Solution"
             onChange={this.onChangeSolution}
@@ -63,6 +91,7 @@ class AddTextSolutionDialog extends React.PureComponent {
           </Button>
           <Button
             color="primary"
+            disabled={!this.state.isCorrectInput}
             onClick={() => onCommit((this.state.solution || "").trim(), taskId)}
             variant="raised"
           >


### PR DESCRIPTION
If text input has non-keyboard characters, or start with empty space, or has only empty spaces:
disable the commit button

Regex provided by Olafs Vandans 
```javascript
    if (/^[^\s][a-zA-Z0-9\t\n ./<>?;:"'`!@#$%^&*()\[\]{}_+=|\\-]*$/
      .test(event.target.value)
    ) {...
```
![image](https://user-images.githubusercontent.com/26617036/44533821-ece8a480-a728-11e8-8b65-0f04c53ef5f7.png)

![image](https://user-images.githubusercontent.com/26617036/44533853-fe31b100-a728-11e8-872a-8d806c7d9e00.png)


***
![image](https://user-images.githubusercontent.com/26617036/44531906-7184f400-a724-11e8-9dca-ae884fc76c12.png)

