### PR TITLE
improve fix on #254 Only show the first 40 characters of text

### DIFF
--- a/src/components/tables/AssignmentsTable.js
+++ b/src/components/tables/AssignmentsTable.js
@@ -57,8 +57,9 @@ const styles = theme => ({
     padding: theme.spacing.unit
   },
   noWrapTooltip: {
-    maxWidth: "none",
-    minWidth: "none"
+    maxWidth: "350px",
+    // so tooltip does not have overflow hidden
+    overflowWrap: "break-word"
   },
   nowrap: {
     whiteSpace: "nowrap"
@@ -165,7 +166,7 @@ class AssignmentsTable extends React.PureComponent {
     if (result.length > MAX_TEXT_LENGTH) {
       return (
         <Tooltip classes={{ tooltip: classes.noWrapTooltip }} title={result}>
-          <span>{result.slice(1, MAX_TEXT_LENGTH)}</span>
+          <span>{result.slice(1, MAX_TEXT_LENGTH) + "..."}</span>
         </Tooltip>
       );
     }


### PR DESCRIPTION
#254 Improve the fix solution, so now when users hover above the text to see the Tooltip, the screen does not have a super long horizontal scroll bar:
![image](https://user-images.githubusercontent.com/26617036/44129239-efc28bfe-a079-11e8-8ad0-c3ddf6de3c44.png)
**To this**:
![image](https://user-images.githubusercontent.com/26617036/44576012-19033480-a7c0-11e8-93ca-32dda26ccb04.png)
