### PR TITLE
Fix: AddActivityDialog select CodeCombat Level autofill #234

### DIFF
--- a/src/components/dialogs/AddActivityDialog.js
+++ b/src/components/dialogs/AddActivityDialog.js
@@ -398,6 +398,13 @@ class AddActivityDialog extends React.PureComponent {
   };
 
   onFieldChange = (field, value) => {
+    const { activity } = this.props;
+    // when edit/update
+    if (activity && activity.id) {
+      this.setState({
+        isCorrectInput: true
+      });
+    }
     let state = {};
     if (field === "type" && value === ACTIVITY_TYPES.jupyterInline.id) {
       state = {

--- a/src/components/dialogs/AddActivityDialog.js
+++ b/src/components/dialogs/AddActivityDialog.js
@@ -407,7 +407,8 @@ class AddActivityDialog extends React.PureComponent {
     }
     if(field==="level" &&  this.state.type === ACTIVITY_TYPES.codeCombat.id){
       state={
-        name : APP_SETTING.levels[value].name
+        name : APP_SETTING.levels[value].name,
+        isCorrectInput: true
       }
     }
     // validate name input


### PR DESCRIPTION
The previous fix   (03feef6) was lost with my recent update. Now it is fixed, again. (When creating a Code Combat level activity, auto fill the name to match the selected level. #234)