### PR TITLE
Fix: YouTube Img on HomeV2 Stretched

### DIFF
--- a/src/containers/HomeV2/SampleCard.jsx
+++ b/src/containers/HomeV2/SampleCard.jsx
@@ -57,7 +57,8 @@ const styles = {
     overflow: "hidden",
     backgroundRepeat: "no-repeat",
     backgroundPosition: "center",
-    backgroundSize: "100% 100%",
+    backgroundSize: "auto 180px",
+    backgroundColor: "black"
   },
 };
 


### PR DESCRIPTION
Fix this issue on HomeV2/HomeScreen:
![image](https://user-images.githubusercontent.com/26617036/44764808-1586f900-ab84-11e8-9b8b-681625b9bfd4.png)

![image](https://user-images.githubusercontent.com/26617036/44764823-246dab80-ab84-11e8-8957-569b43c15cb7.png)

