### PR TITLE
test if LF and CRLF works in Windows

### DIFF
--- a/src/containers/Contribute/Contribute.js
+++ b/src/containers/Contribute/Contribute.js
@@ -120,6 +120,7 @@ function Contribute(props) {
 
           </div>
         </div>
+        <small>Test if LF and CRLF works in Windows Git Env</small>
       </main>
     </React.Fragment>
   );


### PR DESCRIPTION
Hi i noticed about the .gitattributes file and this is to help test if the settings in the gitattributes file works for my windows development environment.

My VScode editor shows all the line endings as CRLF, and it should be converted to LF when i git checkout. 