### PR TITLE
restore Contribute and see if travis build still works

### DIFF
--- a/src/containers/Contribute/Contribute.js
+++ b/src/containers/Contribute/Contribute.js
@@ -117,10 +117,8 @@ function Contribute(props) {
                 </Grid>
               </Grid>
             </div>
-
           </div>
         </div>
-        <small>Test if LF and CRLF works in Windows Git Env</small>
       </main>
     </React.Fragment>
   );


### PR DESCRIPTION
I restored Contribue.jsj back to the original form, and somehow the merge was not picked up by Travis.
Here I submit another PR to trigger Travis Build again, and I will do some research on how to fix the Travis Build timeout 10mins error. 