### PR TITLE
Fix: Home Card CodeCombat click handleClick function error

### DIFF
--- a/src/components/cards/RecommendationCard.js
+++ b/src/components/cards/RecommendationCard.js
@@ -110,7 +110,7 @@ class RecommendationCard extends React.PureComponent {
     return (
       <Card style={styles.card}>
         <Link
-          onClick={this.handleClick}
+          onClick={() => this.handleClick()}
           style={{ textDecoration: "none" }}
           to={
             (activity.type !== "codeCombat" &&

--- a/src/containers/Contribute/Contribute.js
+++ b/src/containers/Contribute/Contribute.js
@@ -117,10 +117,8 @@ function Contribute(props) {
                 </Grid>
               </Grid>
             </div>
-
           </div>
         </div>
-        <small>Test if LF and CRLF works in Windows Git Env</small>
       </main>
     </React.Fragment>
   );


### PR DESCRIPTION
I was still getting the error even after the "quickfix home links #371". So I added a handler to the invocation of handleClick function. 

Now Codecombat card onClick will open a new tab/window, and the other cards' onClick will work fine as well. 