### PR TITLE
multiplayer level fixes

### DIFF
--- a/src/components/activityViews/CodeCombatActivity.js
+++ b/src/components/activityViews/CodeCombatActivity.js
@@ -7,8 +7,7 @@ import PropTypes from "prop-types";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
 import { ACTIVITY_TYPES, CodeCombat_Multiplayer_Data } from "../../services/paths";
-import { externalProfileRefreshRequest } from '../../containers/Account/actions';
-import { assignmentPathProblemSolutionRequest } from "../../containers/Assignments/actions";
+import { externalProfileRefreshRequest } from "../../containers/Account/actions";
 
 
 const externalProfile = {

--- a/src/components/activityViews/CodeCombatActivity.js
+++ b/src/components/activityViews/CodeCombatActivity.js
@@ -6,8 +6,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
-import { ACTIVITY_TYPES } from "../../services/paths";
+import { ACTIVITY_TYPES, CodeCombat_Multiplayer_Data } from "../../services/paths";
 import { externalProfileRefreshRequest } from '../../containers/Account/actions';
+import { assignmentPathProblemSolutionRequest } from "../../containers/Assignments/actions";
 
 
 const externalProfile = {
@@ -35,21 +36,23 @@ class CodeCombatActivity extends React.PureComponent {
   render() {
     const {
       problem,
-      userAchievements,
+      userAchievements
     } = this.props;
 
-    const achievements = ((userAchievements || {}).CodeCombat || {}).achievements;
-    if(!achievements){
+    const codeCombatAchievements = ((userAchievements || {}).CodeCombat || {});
+    const achievements = codeCombatAchievements.achievements;
+    
+    if (!achievements){
       return (
         <Typography>
             Please add your Codecombat profile to complete this assigment.  
         </Typography>
       )
     }
-    const updateCodeCombatAchievements = (<Button color="primary"variant="contained" onClick={this.updateCodeCombatProfile} style={{marginLeft : '10px'}}>
+    const updateCodeCombatAchievements = (<Button color="primary" onClick={this.updateCodeCombatProfile} style={{marginLeft : "10px"}}  variant="contained">
       Update CodeCombat Profile
     </Button>)
-    if(problem.type===ACTIVITY_TYPES.codeCombat.id){
+    if (problem.type===ACTIVITY_TYPES.codeCombat.id){
       const hasLevelCompleted = (achievements[problem.level] || {}).complete;
       if (hasLevelCompleted) {
         this.props.onCommit({
@@ -77,12 +80,12 @@ class CodeCombatActivity extends React.PureComponent {
               </Typography>
               <br/>
               <Button color="primary" variant="contained">
-                <a href={levelURL} target="__blank" style={{color : 'white'}}> Go To Level</a>
+                <a href={levelURL} style={{color : "white"}} target="__blank" > Go To Level</a>
               </Button>
               { updateCodeCombatAchievements }
             </div>
       );
-    }else if(problem.type===ACTIVITY_TYPES.codeCombatNumber.id){
+    } else if (problem.type===ACTIVITY_TYPES.codeCombatNumber.id){
       const totalAchievements = (userAchievements.CodeCombat || {}).totalAchievements || 0;
       const hasNumOfLevelCompleted = totalAchievements >=  problem.count;
       if (hasNumOfLevelCompleted) {
@@ -107,23 +110,35 @@ class CodeCombatActivity extends React.PureComponent {
             <Typography>
               This assigment required to complete {problem.count} levels,
               but you have only compledted levels;
-                You have completed only {totalAchievements || 0} {totalAchievements > 0 ? 'levels' : 'level'} on CodeCombat.
+                You have completed only {totalAchievements || 0} {totalAchievements > 0 ? "levels" : "level"} on CodeCombat.
               </Typography>
               <Typography>
                 Would you like to go to CodeCombat.
               </Typography>
               <br/>
               <Button color="primary"variant="contained">
-                <a href={externalProfile.url} target="__blank" style={{color : 'white'}}> Go To Codecombat</a>
+                <a
+                  href={externalProfile.url}
+                  style={{ color : "white" }}
+                  target="__blank">
+                  Go To Codecombat
+                </a>
               </Button>
               { updateCodeCombatAchievements }
             </div>
       );
-    }else if(problem.type===ACTIVITY_TYPES.codeCombatMultiPlayerLevel.id){
+    } else if (problem.type===ACTIVITY_TYPES.codeCombatMultiPlayerLevel.id){
       const levelUrl = `//codecombat.com/play/level/${problem.level}?team=${problem.team}`;
       const ladderUrl = `//codecombat.com/play/level/${problem.level}`;
-      const userPercentile = achievements.ladders ? (achievements.ladders[`${problem.level}-${problem.level.team}`] || {}).percentile : null;
-      const hasNumOfLevelCompleted = userPercentile >=problem.requiredPercentile          
+      const userPercentile = codeCombatAchievements.ladders ? (codeCombatAchievements.ladders[`${problem.level}-${problem.team}`] || {}).percentile : null;
+      const hasNumOfLevelCompleted = userPercentile >=problem.requiredPercentile;
+      const ladderKey = `${problem.level}-${problem.team}`;
+      const ladder = (codeCombatAchievements.ladders || {})[ladderKey] || {};
+      const ranked = ladder.isRanked ? ladder.rank : 0;
+      const teamColor = CodeCombat_Multiplayer_Data.teams[problem.team].name;
+      const level = CodeCombat_Multiplayer_Data.levels[problem.level].name;
+      const numInRanking = ladder.numInRanking || 0;
+
       if (hasNumOfLevelCompleted) {
         this.props.onCommit({
           type: "SOLUTION",
@@ -148,26 +163,22 @@ class CodeCombatActivity extends React.PureComponent {
           </Typography>
             <Typography>
               {
-                userPercentile 
-                ? `You have got only "${userPercentile}" percentile, but to complete this level you have to get "${problem.requiredPercentile}" percentile.`
-                : `You have not get any percentile from this level. To complete this level you have to get "${problem.requiredPercentile}" percentile.`
+                Object.keys(ladder).length > 0
+                ? `You are ranked ${ranked} out of ${numInRanking} (${ladder.percentile} percentile) playing as ${teamColor} on the ${level} multiplayer level. You have to be better than ${problem.requiredPercentile} percent of the other players to complete this activity.`
+                : `You have not played "${level}" level as "${teamColor}" team.`
               }
-              </Typography>
-              <Typography>
-                Would you like to go to CodeCombat to complete this level.
               </Typography>
               <br/>
               <Button color="primary"variant="contained">
-                <a href={ladderUrl} target="__blank" style={{color : 'white'}}> Go To Ladder</a>
-                </Button>
-                <Button color="primary"variant="contained" style={{marginLeft : '10px'}}>
-                <a href={levelUrl} target="__blank" style={{color : 'white'}}> Go To Level</a>
-                </Button>
+                <a href={ladderUrl} style={{color : "white"}} target="__blank" > Go To Ladder</a>
+              </Button>
+              <Button color="primary" style={{marginLeft : "10px"}} variant="contained" >
+                <a href={levelUrl} style={{color : "white"}} target="__blank" > Go To Level</a>
+              </Button>
                 { updateCodeCombatAchievements }
             </div>
       );
-    }
-    else{
+    } else {
       return (
         <div>
           Wrong Activity Type.

--- a/src/components/dialogs/FetchCodeCombatLevelDialog.js
+++ b/src/components/dialogs/FetchCodeCombatLevelDialog.js
@@ -13,14 +13,15 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import Typography from "@material-ui/core/Typography";
-import { ACTIVITY_TYPES } from '../../services/paths'
+import { ACTIVITY_TYPES,CodeCombat_Multiplayer_Data } from '../../services/paths'
 
 class FetchCodeCombatLevelDialog extends React.PureComponent {
   static propTypes = {
     activity: PropTypes.any,
     codeCombatId: PropTypes.string,
     onClose: PropTypes.func,
-    open: PropTypes.bool
+    open: PropTypes.bool,
+    userAchievements: PropTypes.object
   };
 
   static defaultProps = {
@@ -63,10 +64,17 @@ class FetchCodeCombatLevelDialog extends React.PureComponent {
   };
 
   render() {
-    let { activity, onClose, open } = this.props;
-    if(!activity){
+    let { activity, onClose, open, userAchievements } = this.props;
+    if (!activity){
       return "";
     }
+    const codeCombatAchievements = userAchievements.CodeCombat;
+    const ladderKey = `${activity.level}-${activity.team}`;
+    const ladder = (codeCombatAchievements.ladders || {})[ladderKey] || {};
+    const ranked = ladder.isRanked ? ladder.rank : 0;
+    const teamColor = CodeCombat_Multiplayer_Data.teams[activity.team].name;
+    const level = CodeCombat_Multiplayer_Data.levels[activity.level].name;
+    const numInRanking = ladder.numInRanking || 0;
 
     return (
       <Dialog onClose={onClose} open={open}>
@@ -86,8 +94,11 @@ class FetchCodeCombatLevelDialog extends React.PureComponent {
         }
         {
           activity.type===ACTIVITY_TYPES.codeCombatMultiPlayerLevel.id &&  <Typography>
-          You have not get {`"${activity.requiredPercentile}"`} percentile in {`"${activity.level}"`} level with {`"${activity.team}"`} team on CodeCombat.
-          Would you like to go to CodeCombat to complete this level
+          {
+            Object.keys(ladder).length > 0
+            ? `You are ranked ${ranked} out of ${numInRanking} (${ladder.percentile} percentile) playing as ${teamColor} on the ${level} multiplayer level. You have to be better than ${activity.requiredPercentile} percent of the other players to complete this activity.`
+            : `You have not played "${level}" level as "${teamColor}" team.`
+          }
           </Typography>
         }
          

--- a/src/containers/Path/Path.js
+++ b/src/containers/Path/Path.js
@@ -111,7 +111,8 @@ export class Path extends React.Component {
     pendingProfileUpdate: PropTypes.bool,
     ui: PropTypes.any,
     uid: PropTypes.string,
-    openJestActivity: PropTypes.func
+    openJestActivity: PropTypes.func,
+    userAchievements: PropTypes.object
   };
 
   state = {
@@ -276,7 +277,8 @@ export class Path extends React.Component {
       pendingProfileUpdate,
       ui,
       uid,
-      fetchGithubFiles
+      fetchGithubFiles,
+      userAchievements
     } = this.props;
 
     if (!(pathActivities && pathActivities.path)) {
@@ -435,6 +437,7 @@ export class Path extends React.Component {
           onClose={onCloseDialog}
           onCommit={this.onProfileUpdate}
           open={ui.dialog.type === `${ACTIVITY_TYPES.profile.id}Solution`}
+          userAchievements={userAchievements}
         />
         <ActivitiesTable
           activities={pathActivities.activities || []}
@@ -518,6 +521,7 @@ export class Path extends React.Component {
           codeCombatId={codeCombatProfile && codeCombatProfile.id}
           onClose={onCloseDialog}
           open={ui.dialog.type === "FetchCodeCombatLevel"}
+          userAchievements={userAchievements}
         />
         <RequestMorePathContentDialog
           onClose={this.requestMoreDialogHide}
@@ -538,7 +542,10 @@ const mapStateToProps = (state, ownProps) => ({
   pendingActivityId: state.path.ui.pendingActivityId,
   pendingProfileUpdate: state.path.ui.pendingProfileUpdate,
   ui: state.path.ui,
-  uid: state.firebase.auth.uid
+  uid: state.firebase.auth.uid,
+  userAchievements: (state.firebase.data.userAchievements || {})[
+    ownProps.match.params.accountId || state.firebase.auth.uid
+  ]
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
Codecombat multilevel activity
![screenshot from 2019-02-05 07-32-53](https://user-images.githubusercontent.com/23698860/52249291-5136a380-2918-11e9-9138-7452405bd16a.png)

User achievements in database
![data used for creating the message string](https://user-images.githubusercontent.com/23698860/52249124-72e35b00-2917-11e9-993e-3f89565955ed.png)

Message on assignment submit(if user has not completed that level)
![message on assignment submit](https://user-images.githubusercontent.com/23698860/52249132-7bd42c80-2917-11e9-8ec0-52acd43bc00b.png)

Message on activity fetch in a path(if user has not completed that level)
![message on fetch multi level cc](https://user-images.githubusercontent.com/23698860/52249134-7d9df000-2917-11e9-900b-f2138870a4e3.png)

If user has not played that activity, then he/she will get this message
![screenshot from 2019-02-05 07-13-48](https://user-images.githubusercontent.com/23698860/52249137-7ecf1d00-2917-11e9-90f4-8cd72f175fc2.png)
Multiplayer level assignment marked as completed
![on submit assignment](https://user-images.githubusercontent.com/23698860/52290815-f1cba880-2996-11e9-8e0d-3e272267f441.png)

Videos link showing assignment being completed
https://www.useloom.com/share/194aa54ba8c848ae91427d9160aba205
https://www.useloom.com/share/d8a52d0a461642efba7e4bdb4db64aa3

