### PR TITLE
Added python code analysis to logged_events

### DIFF
--- a/functions/src/processActivitySolution.js
+++ b/functions/src/processActivitySolution.js
@@ -4,46 +4,11 @@ const ONE_HOURS = 3600000;
 
 /**
  * Checks Python activities solutions for skills via lambda function
- * and store result into firebase
+ * and store result into firestore
  * @param {String} activityKey
  * @param {String} userKey
  * @param {Object} data
- * @param {String} data.solution JSON with jupyter solution
- * @param {Number} data.updatedAt
  */
-function analyzePythonCode(activityKey, userKey, data) {
-  return Promise.all([
-    admin
-      .database()
-      .ref("/config/jupyterAnalysisLambdaProcessor")
-      .once("value")
-      .then(snap => snap.val()),
-    admin
-      .database()
-      .ref(`/activities/${activityKey}`)
-      .once("value")
-      .then(snap => snap.val())
-  ]).then(([analyzeUrl, activity]) => {
-    let code, solution;
-    switch (activity.type) {
-      case "jupyterInline":
-        solution = JSON.parse(data.solution);
-        code = solution.cells[activity.code].source.join("");
-
-        return httpUtil
-          .post(analyzeUrl, { [activityKey]: { [userKey]: code } })
-          .then(response =>
-            admin
-              .database()
-              .ref("/analyze/skills")
-              .update(response)
-          )
-          .catch(err => console.error(err));
-      default:
-        return Promise.resolve();
-    }
-  });
-}
 
 function analyzeDiffPythonCode(activityKey, userKey, data) {
   return Promise.all([
@@ -58,34 +23,67 @@ function analyzeDiffPythonCode(activityKey, userKey, data) {
       .once("value")
       .then(snap => snap.val())
   ]).then(([analyzeUrl, activity]) => {
-    let code, solution;
     switch (activity.type) {
       case "jupyterInline":
-        solution = JSON.parse(data.solution);
-        code = solution.cells[activity.code].source.join("");
-
+        let solution = JSON.parse(data.solution);
+        let b1 = solution.result.cells; //given notebook cells
+        let b2 = solution.cells; // solution notebook cells
+        let result = {};
+        // get given and solution code by comparing the code cell for changes
+        b1.filter(
+          o =>
+            !b2.some(v => {
+              if (
+                "code" === v.cell_type &&
+                v.cell_type === o.cell_type &&
+                v.metadata.id === o.metadata.id &&
+                !(v.source.join() === o.source.join())
+              ) {
+                result = {
+                  solutionCode: v.source.join(""),
+                  givenCode: o.source.join("")
+                };
+              }
+            })
+        );
         return httpUtil
-          .post(analyzeUrl, { givenCode: code, solutionCode: code })
+          .post(analyzeUrl, result)
           .then(response =>
             admin
               .firestore()
-              .collection("/diffCodeAnalysis")
+              .collection("/logged_events")
               .add({
-                ...response,
                 uid: userKey,
-                //createdAt: firebase.firestore.Timestamp.now().toMillis(),
+                createdAt: admin.firestore.Timestamp.now().toMillis(),
                 activityKey: activityKey,
-                sGen: True
+                sGen: true,
+                language: "Python 3",
+                difference: response.difference,
+                solutionFeatures: response.solutionFeatures,
+                type: "CODE_ANALYSIS",
+                path: activity.path
               })
           )
-          .catch(err => console.error(err));
+          .catch(err =>
+            admin
+              .firestore()
+              .collection("/logged_events")
+              .add({
+                uid: userKey,
+                createdAt: admin.firestore.Timestamp.now().toMillis(),
+                activityKey: activityKey,
+                sGen: true,
+                type: "CODE_ANALYSIS_ERROR",
+                errorMsg: String(err),
+                path: activity.path
+              })
+          );
       default:
         return Promise.resolve();
     }
   });
 }
 
-exports.analyzePythonCode = analyzePythonCode;
 exports.analyzeDiffPythonCode = analyzeDiffPythonCode;
 /**
  * This function executes 2 tasks:
@@ -99,7 +97,6 @@ exports.analyzeDiffPythonCode = analyzeDiffPythonCode;
  */
 exports.handler = (activityKey, userKey, solution) =>
   Promise.all([
-    analyzePythonCode(activityKey, userKey, solution),
     analyzeDiffPythonCode(activityKey, userKey, solution),
     admin
       .database()


### PR DESCRIPTION
Added python code analysis to logged_events in firestore.
Code analysis is being logged with types - CODE_ANALYSIS and CODE_ANALYSIS_ERROR
- **CODE_ANALYSIS**  - Logged event structure 
 {              uid: //user ID
                createdAt: // Time in milliseconds
                activityKey: // Activity ID
                sGen: true // Boolean value set to true as it is server generated event
                language: "Python 3", // hard-coded as the current code-analysis works only for python3
                difference: // Code analysis features on the diff of given and solution code
                solutionFeatures: // Code analysis features on the solution code
                type: "CODE_ANALYSIS", //Type 
                path: //Path ID
}
- **CODE_ANALYSIS_ERROR** - logged_event structure
This event type is logged when there's an error while executing the code analysis serverless function
{
                uid: /User ID
                createdAt: // Time in milliseconds
                activityKey: //Activity ID
                sGen: true,// Boolean value set to true as it is server generated event
                type: "CODE_ANALYSIS_ERROR", // Type
                errorMsg: String(err), // Error msg
                path: // Path ID
}