### PR TITLE
Admin Custom Analysis for firebase queries

### DIFF
--- a/functions/src/runCustomAnalysis.js
+++ b/functions/src/runCustomAnalysis.js
@@ -50,13 +50,18 @@ function runJupyterAnalysis(analysisNotebook, solutions) {
  * @param {String} data.uid
  * @param {Object} data.solutions
  * @param {String} data.analysisID
+ * @param {String} data.analysisType - customAnalysis or adminCustomAnalysis
  * @param {Object} context
  */
 function runCustomAnalysis(data, context) {
   console.log(data);
+  let firestore_node = "customAnalysis";
+  if (data.analysisType) {
+    firestore_node = data.analysisType;
+  }
   return admin
     .firestore()
-    .collection("/customAnalysis")
+    .collection(`/${firestore_node}`)
     .doc(data.analysisID)
     .get()
     .then(doc => {

--- a/src/achievementsApp/reducer.js
+++ b/src/achievementsApp/reducer.js
@@ -18,11 +18,13 @@ import { problem } from "../containers/Activity/reducer";
 import { root } from "../containers/Root/reducer";
 import { task } from "../containers/Task/reducer";
 import { tasks } from "../containers/Tasks/reducer";
-import { customAnalysis } from "../containers/CustomAnalysis/reducer.js";
+import { customAnalysis } from "../containers/CustomAnalysis/reducer";
+import { adminCustomAnalysis } from "../containers/AdminCustomAnalysis/reducer";
 
 export default combineReducers({
   account,
   admin,
+  adminCustomAnalysis,
   appFrame,
   assignments,
   cohorts,

--- a/src/components/dialogs/AddAdminCustomQueryDialog.js
+++ b/src/components/dialogs/AddAdminCustomQueryDialog.js
@@ -50,7 +50,13 @@ class AddAdminCustomQueryDialog extends React.PureComponent {
     isCorrectInput: false,
     type: "Firebase",
     query: {
-      firebase: { ref: "", orderByChild: "", equalTo: "" },
+      firebase: {
+        ref: "",
+        orderByChild: "",
+        equalTo: "",
+        limitToFirst: "",
+        limitToLast: ""
+      },
       firestore: {}
     }
   };
@@ -265,7 +271,13 @@ class AddAdminCustomQueryDialog extends React.PureComponent {
 
   firebaseQueryHandler(data) {
     let parsedData = {
-      firebase: { ref: "", orderByChild: "", equalTo: "" }
+      firebase: {
+        ref: "",
+        orderByChild: "",
+        equalTo: "",
+        limitToFirst: "",
+        limitToLast: ""
+      }
     };
     Object.keys(data.firebase).forEach(option => {
       parsedData.firebase[option] = this.parseValue(data.firebase[option]);

--- a/src/components/dialogs/AddAdminCustomQueryDialog.js
+++ b/src/components/dialogs/AddAdminCustomQueryDialog.js
@@ -30,7 +30,6 @@ import RadioGroup from "@material-ui/core/RadioGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormControl from "@material-ui/core/FormControl";
 import TextField from "@material-ui/core/TextField";
-import InputAdornment from "@material-ui/core/InputAdornment";
 
 class AddAdminCustomQueryDialog extends React.PureComponent {
   constructor(props) {
@@ -47,11 +46,11 @@ class AddAdminCustomQueryDialog extends React.PureComponent {
     activeStep: 0,
     skipped: new Set(),
     open: false,
-    fileName: "",
+    name: "",
     isCorrectInput: false,
     type: "Firebase",
     query: {
-      firebase: { ref: "", orderByChild: "", equalTo: "", once: "" },
+      firebase: { ref: "", orderByChild: "", equalTo: "" },
       firestore: {}
     }
   };
@@ -107,16 +106,11 @@ class AddAdminCustomQueryDialog extends React.PureComponent {
                     ? ""
                     : "Name should not be empty or too long or have invalid characters"
                 }
-                label="Query Results File Name"
+                label="Query Name"
                 margin="dense"
-                onChange={e => this.onFieldChange("fileName", e.target.value)}
+                onChange={e => this.onFieldChange("name", e.target.value)}
                 required
-                value={this.state.fileName || ""}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position="end">.json</InputAdornment>
-                  )
-                }}
+                value={this.state.name || ""}
               />
               <FirebaseQueryTable
                 classes={this.props.classes}
@@ -139,16 +133,11 @@ class AddAdminCustomQueryDialog extends React.PureComponent {
                     ? ""
                     : "Name should not be empty or too long or have invalid characters"
                 }
-                label="Query Results File Name"
+                label="Query Name"
                 margin="dense"
-                onChange={e => this.onFieldChange("fileName", e.target.value)}
+                onChange={e => this.onFieldChange("name", e.target.value)}
                 required
-                value={this.state.fileName || ""}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position="end">.json</InputAdornment>
-                  )
-                }}
+                value={this.state.name || ""}
               />
               <FirestoreQueryTable
                 classes={this.props.classes}
@@ -230,7 +219,7 @@ class AddAdminCustomQueryDialog extends React.PureComponent {
   };
   onFieldChange = (field, value) => {
     // validate name input
-    if (field === "fileName") {
+    if (field === "name") {
       if (AddName.test(value) && NoStartWhiteSpace.test(value)) {
         this.setState({
           isCorrectInput: true
@@ -245,24 +234,52 @@ class AddAdminCustomQueryDialog extends React.PureComponent {
   };
 
   isIncorrect = () => {
-    if (this.state.fileName && this.state.isCorrectInput) {
+    if (this.state.name && this.state.isCorrectInput) {
       return false;
     } else {
       return true;
     }
   };
 
+  parseValue(v) {
+    if (v === "") {
+      return undefined;
+    }
+
+    if (/^"(.*)"$/.test(v)) {
+      return v.substring(1, v.length - 1);
+    } else if (/^-?[0-9]+$/.test(v)) {
+      return parseInt(v, 10);
+    }
+    switch (v) {
+      case "true":
+        return true;
+      case "false":
+        return false;
+      case "null":
+        return null;
+      default:
+        return v;
+    }
+  }
+
   firebaseQueryHandler(data) {
+    let parsedData = {
+      firebase: { ref: "", orderByChild: "", equalTo: "" }
+    };
+    Object.keys(data.firebase).forEach(option => {
+      parsedData.firebase[option] = this.parseValue(data.firebase[option]);
+    });
     this.setState({
       ...this.state,
-      query: { fileName: this.state.fileName + ".json", query: data }
+      query: { name: this.state.name, query: parsedData }
     });
   }
 
   firestoreQueryHandler(data) {
     this.setState({
       ...this.state,
-      query: { fileName: this.state.fileName + ".json", query: data }
+      query: { name: this.state.name, query: data }
     });
   }
 

--- a/src/components/tables/FirebaseQueryTable.js
+++ b/src/components/tables/FirebaseQueryTable.js
@@ -23,7 +23,7 @@ class FirebaseQueryTable extends React.PureComponent {
   };
   state = {
     query: {
-      firebase: { ref: "", orderByChild: "", equalTo: "", once: "" }
+      firebase: { ref: "", orderByChild: "", equalTo: "" }
     }
   };
 
@@ -38,9 +38,6 @@ class FirebaseQueryTable extends React.PureComponent {
         break;
       case "equalTo":
         data.firebase.equalTo = value;
-        break;
-      case "once":
-        data.firebase.once = value;
         break;
       default:
         break;
@@ -71,14 +68,8 @@ class FirebaseQueryTable extends React.PureComponent {
         <TableBody>
           <TableRow key="firebase">
             <TableCell align="right">
-              <Typography className={classes.instructions}>firebase</Typography>
-            </TableCell>
-            <TableCell align="left"> </TableCell>
-          </TableRow>
-          <TableRow key="database">
-            <TableCell align="right">
               <Typography className={classes.instructions}>
-                .database()
+                firebase.database()
               </Typography>
             </TableCell>
             <TableCell align="left"> </TableCell>
@@ -86,7 +77,7 @@ class FirebaseQueryTable extends React.PureComponent {
           <TableRow key="ref">
             <TableCell align="right">
               <Typography className={classes.instructions}>
-                .ref("{this.state.query.firebase.ref}")
+                .ref({this.state.query.firebase.ref})
               </Typography>
             </TableCell>
             <TableCell align="left">
@@ -104,8 +95,7 @@ class FirebaseQueryTable extends React.PureComponent {
           <TableRow key="orderByChild">
             <TableCell align="right">
               <Typography className={classes.instructions}>
-                .orderByChild("{this.state.query.firebase.orderByChild}
-                ")
+                .orderByChild({this.state.query.firebase.orderByChild})
               </Typography>
             </TableCell>
             <TableCell align="left">
@@ -126,7 +116,7 @@ class FirebaseQueryTable extends React.PureComponent {
           <TableRow key="equalTo">
             <TableCell align="right">
               <Typography className={classes.instructions}>
-                .equalTo("{this.state.query.firebase.equalTo}")
+                .equalTo({this.state.query.firebase.equalTo})
               </Typography>
             </TableCell>
             <TableCell align="left">
@@ -144,20 +134,10 @@ class FirebaseQueryTable extends React.PureComponent {
           <TableRow key="once">
             <TableCell align="right">
               <Typography className={classes.instructions}>
-                .once("{this.state.query.firebase.once}")
+                .once("value")
               </Typography>
             </TableCell>
-            <TableCell align="left">
-              <TextField
-                id="outlined-name"
-                label="once"
-                className={classes.textField}
-                value={this.state.query.firebase.once}
-                onChange={e => this.onFieldChange("once", e.target.value)}
-                margin="dense"
-                variant="outlined"
-              />
-            </TableCell>
+            <TableCell align="left" />
           </TableRow>
         </TableBody>
       </Table>

--- a/src/components/tables/FirebaseQueryTable.js
+++ b/src/components/tables/FirebaseQueryTable.js
@@ -1,0 +1,168 @@
+/**
+ * @file Firebase Query  Table
+ * @author Aishwarya Lakshminarasimhan <aishwaryarln@gmail.com>
+ * @created 02.07.18
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+
+//Import MaterialUI components
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import TextField from "@material-ui/core/TextField";
+import Typography from "@material-ui/core/Typography";
+
+class FirebaseQueryTable extends React.PureComponent {
+  static propTypes = {
+    classes: PropTypes.object.isRequired,
+    firebaseQueryHandler: PropTypes.func
+  };
+  state = {
+    query: {
+      firebase: { ref: "", orderByChild: "", equalTo: "", once: "" }
+    }
+  };
+
+  onFieldChange = (field, value) => {
+    let data = { ...this.state.query };
+    switch (field) {
+      case "ref":
+        data.firebase.ref = value;
+        break;
+      case "orderByChild":
+        data.firebase.orderByChild = value;
+        break;
+      case "equalTo":
+        data.firebase.equalTo = value;
+        break;
+      case "once":
+        data.firebase.once = value;
+        break;
+      default:
+        break;
+    }
+    this.setState({ ...this.state, query: data });
+    this.props.firebaseQueryHandler(data);
+  };
+
+  isIncorrect = () => {
+    if (this.state.name && this.state.isCorrectInput) {
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <Table className={classes.table} size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell align="left" />
+            <TableCell align="left" />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow key="firebase">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>firebase</Typography>
+            </TableCell>
+            <TableCell align="left"> </TableCell>
+          </TableRow>
+          <TableRow key="database">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .database()
+              </Typography>
+            </TableCell>
+            <TableCell align="left"> </TableCell>
+          </TableRow>
+          <TableRow key="ref">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .ref("{this.state.query.firebase.ref}")
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <TextField
+                id="outlined-name"
+                label="ref"
+                className={classes.textField}
+                value={this.state.query.firebase.ref}
+                onChange={e => this.onFieldChange("ref", e.target.value)}
+                margin="dense"
+                variant="outlined"
+              />{" "}
+            </TableCell>
+          </TableRow>
+          <TableRow key="orderByChild">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .orderByChild("{this.state.query.firebase.orderByChild}
+                ")
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              {" "}
+              <TextField
+                id="outlined-name"
+                label="orderByChild"
+                className={classes.textField}
+                value={this.state.query.firebase.orderByChild}
+                onChange={e =>
+                  this.onFieldChange("orderByChild", e.target.value)
+                }
+                margin="dense"
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+          <TableRow key="equalTo">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .equalTo("{this.state.query.firebase.equalTo}")
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <TextField
+                id="outlined-name"
+                label="equalTo"
+                className={classes.textField}
+                value={this.state.query.firebase.equalTo}
+                onChange={e => this.onFieldChange("equalTo", e.target.value)}
+                margin="dense"
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+          <TableRow key="once">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .once("{this.state.query.firebase.once}")
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <TextField
+                id="outlined-name"
+                label="once"
+                className={classes.textField}
+                value={this.state.query.firebase.once}
+                onChange={e => this.onFieldChange("once", e.target.value)}
+                margin="dense"
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+  }
+}
+
+export default FirebaseQueryTable;

--- a/src/components/tables/FirebaseQueryTable.js
+++ b/src/components/tables/FirebaseQueryTable.js
@@ -23,7 +23,13 @@ class FirebaseQueryTable extends React.PureComponent {
   };
   state = {
     query: {
-      firebase: { ref: "", orderByChild: "", equalTo: "" }
+      firebase: {
+        ref: "",
+        orderByChild: "",
+        equalTo: "",
+        limitToFirst: "",
+        limitToLast: ""
+      }
     }
   };
 
@@ -38,6 +44,12 @@ class FirebaseQueryTable extends React.PureComponent {
         break;
       case "equalTo":
         data.firebase.equalTo = value;
+        break;
+      case "limitToFirst":
+        data.firebase.limitToFirst = value;
+        break;
+      case "limitToLast":
+        data.firebase.limitToLast = value;
         break;
       default:
         break;
@@ -126,6 +138,46 @@ class FirebaseQueryTable extends React.PureComponent {
                 className={classes.textField}
                 value={this.state.query.firebase.equalTo}
                 onChange={e => this.onFieldChange("equalTo", e.target.value)}
+                margin="dense"
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+          <TableRow key="limitToFirst">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .limitToFirst({this.state.query.firebase.limitToFirst})
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <TextField
+                id="outlined-name"
+                label="limitToFirst"
+                className={classes.textField}
+                value={this.state.query.firebase.limitToFirst}
+                onChange={e =>
+                  this.onFieldChange("limitToFirst", e.target.value)
+                }
+                margin="dense"
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+          <TableRow key="limitToLast">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .limitToLast({this.state.query.firebase.limitToLast})
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <TextField
+                id="outlined-name"
+                label="limitToLast"
+                className={classes.textField}
+                value={this.state.query.firebase.limitToLast}
+                onChange={e =>
+                  this.onFieldChange("limitToLast", e.target.value)
+                }
                 margin="dense"
                 variant="outlined"
               />

--- a/src/components/tables/FirestoreQueryTable.js
+++ b/src/components/tables/FirestoreQueryTable.js
@@ -1,0 +1,251 @@
+/**
+ * @file Firestore Query  Table
+ * @author Aishwarya Lakshminarasimhan <aishwaryarln@gmail.com>
+ * @created 03.07.18
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+
+//Import MaterialUI components
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import TextField from "@material-ui/core/TextField";
+import Typography from "@material-ui/core/Typography";
+
+class FirestoreQueryTable extends React.PureComponent {
+  static propTypes = {
+    classes: PropTypes.object.isRequired,
+    firestoreQueryHandler: PropTypes.func
+  };
+  state = {
+    query: {
+      firestore: {
+        collection: "",
+        doc: "",
+        whereTest: "",
+        whereCondition: "",
+        whereTestValue: "",
+        orderBy: "",
+        orderByDirection: "",
+        limit: ""
+      }
+    }
+  };
+
+  onFieldChange = (field, value) => {
+    let data = { ...this.state.query };
+    switch (field) {
+      case "collection":
+        data.firestore.collection = value;
+        break;
+      case "doc":
+        data.firestore.doc = value;
+        break;
+      case "whereTest":
+        data.firestore.whereTest = value;
+        break;
+      case "whereCondition":
+        data.firestore.whereCondition = value;
+        break;
+      case "whereTestValue":
+        data.firestore.whereTestValue = value;
+        break;
+      case "orderBy":
+        data.firestore.orderBy = value;
+        break;
+      case "orderByDirection":
+        data.firestore.orderByDirection = value;
+        break;
+      case "limit":
+        data.firestore.limit = value;
+        break;
+      default:
+        break;
+    }
+    this.setState({ ...this.state, query: data });
+    this.props.firestoreQueryHandler(data);
+  };
+
+  isIncorrect = () => {
+    if (this.state.name && this.state.isCorrectInput) {
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <Table className={classes.table} size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell align="left" />
+            <TableCell align="left" />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow key="firebase">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>firebase</Typography>
+            </TableCell>
+            <TableCell align="left"> </TableCell>
+          </TableRow>
+          <TableRow key="firestore">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .firestore()
+              </Typography>
+            </TableCell>
+            <TableCell align="left"> </TableCell>
+          </TableRow>
+          <TableRow key="collection">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .collection("{this.state.query.firestore.collection}")
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <TextField
+                id="outlined-name"
+                label="collection"
+                className={classes.textField}
+                value={this.state.query.firestore.collection}
+                onChange={e => this.onFieldChange("collection", e.target.value)}
+                margin="dense"
+                variant="outlined"
+              />{" "}
+            </TableCell>
+          </TableRow>
+          <TableRow key="doc">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .doc("{this.state.query.firestore.doc}
+                ")
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              {" "}
+              <TextField
+                id="outlined-name"
+                label="doc"
+                className={classes.textField}
+                value={this.state.query.firestore.doc}
+                onChange={e => this.onFieldChange("doc", e.target.value)}
+                margin="dense"
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+          <TableRow key="where">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .where( "{this.state.query.firestore.whereTest}", "
+                {this.state.query.firestore.whereCondition}", "
+                {this.state.query.firestore.whereTestValue}" )
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <div>
+                <TextField
+                  id="outlined-name"
+                  label="whereTest"
+                  className={classes.textField}
+                  value={this.state.query.firestore.whereTest}
+                  onChange={e =>
+                    this.onFieldChange("whereTest", e.target.value)
+                  }
+                  margin="dense"
+                  variant="outlined"
+                />
+                <TextField
+                  id="outlined-name"
+                  label="whereCondition"
+                  className={classes.textField}
+                  value={this.state.query.firestore.whereCondition}
+                  onChange={e =>
+                    this.onFieldChange("whereCondition", e.target.value)
+                  }
+                  margin="dense"
+                  variant="outlined"
+                />
+                <TextField
+                  id="outlined-name"
+                  label="whereTestValue"
+                  className={classes.textField}
+                  value={this.state.query.firestore.whereTestValue}
+                  onChange={e =>
+                    this.onFieldChange("whereTestValue", e.target.value)
+                  }
+                  margin="dense"
+                  variant="outlined"
+                />
+              </div>
+            </TableCell>
+          </TableRow>
+          <TableRow key="orderBy">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .orderBy("{this.state.query.firestore.orderBy}","
+                {this.state.query.firestore.orderByDirection}")
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <TextField
+                id="outlined-name"
+                label="orderBy"
+                className={classes.textField}
+                value={this.state.query.firestore.orderBy}
+                onChange={e => this.onFieldChange("orderBy", e.target.value)}
+                margin="dense"
+                variant="outlined"
+              />
+              <TextField
+                id="outlined-name"
+                label="orderByDirection"
+                className={classes.textField}
+                value={this.state.query.firestore.orderByDirection}
+                onChange={e =>
+                  this.onFieldChange("orderByDirection", e.target.value)
+                }
+                margin="dense"
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+          <TableRow key="limit">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>
+                .limit("{this.state.query.firestore.limit}")
+              </Typography>
+            </TableCell>
+            <TableCell align="left">
+              <TextField
+                id="outlined-name"
+                label="limit"
+                className={classes.textField}
+                value={this.state.query.firestore.limit}
+                onChange={e => this.onFieldChange("limit", e.target.value)}
+                margin="dense"
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+          <TableRow key="get">
+            <TableCell align="right">
+              <Typography className={classes.instructions}>.get()</Typography>
+            </TableCell>
+            <TableCell align="left"> </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+  }
+}
+
+export default FirestoreQueryTable;

--- a/src/containers/AdminCustomAnalysis/AdminCustomAnalysis.js
+++ b/src/containers/AdminCustomAnalysis/AdminCustomAnalysis.js
@@ -90,7 +90,7 @@ class AdminCustomAnalysis extends React.PureComponent {
     onOpen: PropTypes.func,
     deleteAdminCustomAnalysis: PropTypes.func,
     addAdminCustomAnalysis: PropTypes.func,
-    analyseRequest: PropTypes.func,
+    onAnalyse: PropTypes.func,
     adminAnalysis: PropTypes.object,
     analysisResponse: PropTypes.object
   };
@@ -175,17 +175,32 @@ class AdminCustomAnalysis extends React.PureComponent {
       let results = analysisResponse.results
         ? analysisResponse.results
         : analysisResponse.result;
-      return {
-        response: {
-          data: {
-            isComplete: results.isComplete,
-            jsonFeedback: results.jsonFeedback,
-            htmlFeedback: results.htmlFeedback,
-            textFeedback: results.textFeedback,
-            ipynbFeedback: analysisResponse.ipynb
+      if (results) {
+        return {
+          response: {
+            data: {
+              isComplete: results.isComplete,
+              jsonFeedback: results.jsonFeedback,
+              htmlFeedback: results.htmlFeedback,
+              textFeedback: results.textFeedback,
+              ipynbFeedback: analysisResponse.ipynb
+            }
           }
-        }
-      };
+        };
+      } else {
+        return {
+          response: {
+            data: {
+              isComplete: false,
+              jsonFeedback: "",
+              htmlFeedback: "Please write into results.json file.",
+              textFeedback: "",
+              ipynbFeedback: analysisResponse.ipynb
+            }
+          }
+        };
+      }
+
       //this.setState({ displayResponse: "Loaded" });
     }
     return {
@@ -194,8 +209,7 @@ class AdminCustomAnalysis extends React.PureComponent {
           isComplete: false,
           jsonFeedback: { dummyKey: "dummyValue" },
           htmlFeedback: "<h1>Sample HTML Response</h1>",
-          textFeedback: "Sample Text Response",
-          ipynbFeedback: analysisResponse.ipynb
+          textFeedback: "Sample Text Response"
         }
       }
     };

--- a/src/containers/AdminCustomAnalysis/AdminCustomAnalysis.js
+++ b/src/containers/AdminCustomAnalysis/AdminCustomAnalysis.js
@@ -1,0 +1,61 @@
+/**
+ * @file Admin Custom Analysis container module
+ * @author Aishwarya Lakshminarasimhan <aishwaryarln@gmail.com>
+ * @created 02.07.18
+ */
+
+import * as React from "react";
+import { withStyles } from "@material-ui/core/styles";
+import PropTypes from "prop-types";
+import { compose } from "redux";
+import { connect } from "react-redux";
+
+import { sagaInjector } from "../../services/saga";
+import sagas from "./sagas";
+import { adminCustomAnalysisOpen } from "./actions";
+
+const styles = () => ({
+  root: {
+    width: "100%"
+  }
+});
+
+class AdminCustomAnalysis extends React.PureComponent {
+  static propTypes = {
+    classes: PropTypes.object,
+    isAdmin: PropTypes.bool,
+    onOpen: PropTypes.func
+  };
+
+  componentDidMount() {
+    this.props.onOpen();
+  }
+
+  render() {
+    const { classes, isAdmin } = this.props;
+    return (
+      <div className={classes.root}>
+        <div>Admin Status : {String(isAdmin)}</div>
+      </div>
+    );
+  }
+}
+
+sagaInjector.inject(sagas);
+
+const mapStateToProps = state => ({
+  uid: state.firebase.auth.uid,
+  isAdmin: state.adminCustomAnalysis.isAdmin
+});
+
+const mapDispatchToProps = {
+  onOpen: adminCustomAnalysisOpen
+};
+
+export default compose(
+  withStyles(styles),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )
+)(AdminCustomAnalysis);

--- a/src/containers/AdminCustomAnalysis/AdminCustomAnalysis.js
+++ b/src/containers/AdminCustomAnalysis/AdminCustomAnalysis.js
@@ -164,34 +164,63 @@ class AdminCustomAnalysis extends React.PureComponent {
   handleSubmit = () => {
     this.setState({ displayResponse: "Loading" });
     this.props.onAnalyse(this.state.adminAnalysisID, this.state.query);
-    //console.log("submitted");
   };
 
   handleResponseClear = () => {
     this.setState({ displayResponse: "Clear" });
-    //console.log("Clear Response");
   };
 
   getTaskInfo = analysisResponse => {
     if (analysisResponse && !isEmpty(analysisResponse)) {
-      //console.log("Setting state to loaded");
-      this.setState({ displayResponse: "Loaded" });
+      let results = analysisResponse.results
+        ? analysisResponse.results
+        : analysisResponse.result;
+      return {
+        response: {
+          data: {
+            isComplete: results.isComplete,
+            jsonFeedback: results.jsonFeedback,
+            htmlFeedback: results.htmlFeedback,
+            textFeedback: results.textFeedback,
+            ipynbFeedback: analysisResponse.ipynb
+          }
+        }
+      };
+      //this.setState({ displayResponse: "Loaded" });
     }
     return {
       response: {
         data: {
           isComplete: false,
-          jsonFeedback: analysisResponse,
+          jsonFeedback: { dummyKey: "dummyValue" },
           htmlFeedback: "<h1>Sample HTML Response</h1>",
-          textFeedback: "Sample Text Response"
+          textFeedback: "Sample Text Response",
+          ipynbFeedback: analysisResponse.ipynb
         }
       }
     };
   };
 
+  getCustomResponseForm = () => {
+    if (this.props.analysisResponse && !isEmpty(this.props.analysisResponse)) {
+      const taskInfo = this.getTaskInfo(this.props.analysisResponse);
+      return <CustomTaskResponseForm taskInfo={taskInfo} />;
+    } else {
+      return (
+        <LinearProgress
+          className={
+            this.state.displayResponse === "Loading"
+              ? ""
+              : this.props.classes.hidden
+          }
+        />
+      );
+    }
+  };
+
   render() {
-    const { classes, isAdmin, adminAnalysis, analysisResponse } = this.props;
-    const taskInfo = this.getTaskInfo(analysisResponse);
+    const { classes, isAdmin, adminAnalysis } = this.props;
+
     if (!isAdmin) {
       return (
         <Typography variant="body2" gutterBottom>
@@ -315,20 +344,7 @@ class AdminCustomAnalysis extends React.PureComponent {
             this.state.displayResponse === "Clear" ? classes.hidden : ""
           }
         >
-          {!(taskInfo && isEmpty(taskInfo)) ? (
-            <LinearProgress
-              className={
-                this.state.displayResponse === "Loading" ? "" : classes.hidden
-              }
-            />
-          ) : (
-            <CustomTaskResponseForm
-              className={
-                this.state.displayResponse === "Loaded" ? "" : classes.hidden
-              }
-              taskInfo={taskInfo}
-            />
-          )}
+          {this.getCustomResponseForm()}
         </div>
       </div>
     );

--- a/src/containers/AdminCustomAnalysis/AdminCustomAnalysis.js
+++ b/src/containers/AdminCustomAnalysis/AdminCustomAnalysis.js
@@ -10,13 +10,68 @@ import PropTypes from "prop-types";
 import { compose } from "redux";
 import { connect } from "react-redux";
 
+import { firestoreConnect } from "react-redux-firebase";
+
 import { sagaInjector } from "../../services/saga";
 import sagas from "./sagas";
-import { adminCustomAnalysisOpen } from "./actions";
 
-const styles = () => ({
+import {
+  adminCustomAnalysisOpen,
+  addAdminCustomAnalysisRequest,
+  deleteAdminCustomAnalysisRequest
+} from "./actions";
+
+// Import components
+import CustomAnalysisMenu from "../../components/menus/CustomAnalysisMenu";
+import AddCustomAnalysisDialog from "../../components/dialogs/AddCustomAnalysisDialog";
+import DeleteCustomAnalysisDialog from "../../components/dialogs/DeleteCustomAnalysisDialog";
+import AddAdminCustomQueryDialog from "../../components/dialogs/AddAdminCustomQueryDialog";
+
+//Import Material UI components
+import { Typography } from "@material-ui/core";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import DeleteIcon from "@material-ui/icons/Delete";
+import Button from "@material-ui/core/Button";
+
+const styles = theme => ({
+  activitySelection: {
+    width: "100%",
+    maxWidth: 360,
+    backgroundColor: theme.palette.background.paper
+  },
   root: {
     width: "100%"
+  },
+  table: {
+    backgroundColor: theme.palette.background.paper,
+    overflowX: "auto",
+    minWidth: 650
+  },
+  buttonContainer: {
+    textAlign: "center"
+  },
+  analyseButton: {
+    display: "inline-block"
+  },
+  analysisTypeSelection: {
+    marginLeft: 10
+  },
+  heading: {
+    fontSize: theme.typography.pxToRem(15),
+    flexBasis: "33.33%",
+    flexShrink: 0
+  },
+  secondaryHeading: {
+    fontSize: theme.typography.pxToRem(15),
+    color: theme.palette.text.secondary
   }
 });
 
@@ -24,18 +79,173 @@ class AdminCustomAnalysis extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object,
     isAdmin: PropTypes.bool,
-    onOpen: PropTypes.func
+    onOpen: PropTypes.func,
+    deleteAdminCustomAnalysis: PropTypes.func,
+    addAdminCustomAnalysis: PropTypes.func,
+    adminAnalysis: PropTypes.object
   };
 
   componentDidMount() {
     this.props.onOpen();
+
+    this.listHandler = this.listHandler.bind(this);
+    this.addAdminCustomAnalysisHandler = this.addAdminCustomAnalysisHandler.bind(
+      this
+    );
+    this.deleteAdminCustomAnalysisHandler = this.deleteAdminCustomAnalysisHandler.bind(
+      this
+    );
+    this.addCustomQueryHandler = this.addCustomQueryHandler.bind(this);
   }
 
+  state = {
+    adminAnalysisID: "",
+    query: {
+      firebase: [],
+      firestore: []
+    }
+  };
+
+  listHandler(listType, listValue) {
+    let data = {};
+    switch (listType) {
+      case "Analysis":
+        data = { adminAnalysisID: listValue.id };
+        break;
+      default:
+        break;
+    }
+    this.setState({ ...this.state, ...data });
+  }
+
+  addAdminCustomAnalysisHandler(url, name) {
+    this.props.addAdminCustomAnalysis(url, name);
+  }
+
+  deleteAdminCustomAnalysisHandler(analysisID) {
+    this.props.deleteAdminCustomAnalysis(analysisID);
+  }
+
+  addCustomQueryHandler(type, query) {
+    let tempQuery = { ...this.state.query };
+    switch (type) {
+      case "Firebase":
+        tempQuery.firebase.push(query);
+        break;
+      case "Firestore":
+        tempQuery.firestore.push(query);
+        break;
+      default:
+        break;
+    }
+    this.setState({ ...this.state, query: tempQuery });
+  }
+
+  handleClear = () => {
+    this.setState({
+      query: {
+        firebase: [],
+        firestore: []
+      }
+    });
+  };
   render() {
-    const { classes, isAdmin } = this.props;
+    const { classes, isAdmin, adminAnalysis } = this.props;
+
+    if (!isAdmin) {
+      return (
+        <Typography variant="body2" gutterBottom>
+          Sorry! This page is only viewable by admins.
+        </Typography>
+      );
+    }
     return (
       <div className={classes.root}>
-        <div>Admin Status : {String(isAdmin)}</div>
+        <ExpansionPanel defaultExpanded={true}>
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            <Typography className={classes.heading}>Queries</Typography>
+            <Typography className={classes.secondaryHeading}>
+              Expand to view queries created
+            </Typography>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            <pre>{JSON.stringify(this.state.query, null, 2)}</pre>
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
+        <ExpansionPanel defaultExpanded={true}>
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1b-content"
+            id="panel1b-header"
+          >
+            <Typography className={classes.heading}>
+              Query and Analysis
+            </Typography>
+            <Typography className={classes.secondaryHeading}>
+              Expand to view query and Analysis options
+            </Typography>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            <Table className={classes.table} size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell align="left">Add/Clear Queries</TableCell>
+                  <TableCell align="left">Select analysis</TableCell>
+                  <TableCell align="left">Add/Delete Analysis</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow key="menu-options">
+                  <TableCell align="left">
+                    <AddAdminCustomQueryDialog
+                      classes={classes}
+                      addCustomQueryHandler={this.addCustomQueryHandler}
+                    />
+                    <br />
+                    <Button
+                      variant="outlined"
+                      color="primary"
+                      onClick={this.handleClear}
+                    >
+                      <DeleteIcon className={classes.deleteIcon} />
+                      Clear all queries&nbsp;
+                    </Button>
+                  </TableCell>
+                  <TableCell align="right">
+                    <CustomAnalysisMenu
+                      classes={classes}
+                      listHandler={this.listHandler}
+                      type={""}
+                      listType={"Analysis"}
+                      menuContent={adminAnalysis}
+                    />
+                  </TableCell>
+                  <TableCell align="left">
+                    <AddCustomAnalysisDialog
+                      classes={classes}
+                      addCustomAnalysisHandler={
+                        this.addAdminCustomAnalysisHandler
+                      }
+                    />
+                    <br />
+                    <DeleteCustomAnalysisDialog
+                      classes={classes}
+                      myAnalysis={adminAnalysis}
+                      listHandler={this.listHandler}
+                      deleteCustomAnalysisHandler={
+                        this.deleteAdminCustomAnalysisHandler
+                      }
+                    />
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
       </div>
     );
   }
@@ -45,15 +255,30 @@ sagaInjector.inject(sagas);
 
 const mapStateToProps = state => ({
   uid: state.firebase.auth.uid,
-  isAdmin: state.adminCustomAnalysis.isAdmin
+  isAdmin: state.adminCustomAnalysis.isAdmin,
+  adminAnalysis: state.firestore.data.adminAnalysis
 });
 
 const mapDispatchToProps = {
-  onOpen: adminCustomAnalysisOpen
+  onOpen: adminCustomAnalysisOpen,
+  addAdminCustomAnalysis: addAdminCustomAnalysisRequest,
+  deleteAdminCustomAnalysis: deleteAdminCustomAnalysisRequest
 };
 
 export default compose(
   withStyles(styles),
+  firestoreConnect((ownProps, store) => {
+    const firebaseAuth = store.getState().firebase.auth;
+    return firebaseAuth.isEmpty
+      ? []
+      : [
+          {
+            collection: "adminCustomAnalysis",
+            where: [["uid", "==", firebaseAuth.uid]],
+            storeAs: "adminAnalysis"
+          }
+        ];
+  }),
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/containers/AdminCustomAnalysis/actions.js
+++ b/src/containers/AdminCustomAnalysis/actions.js
@@ -1,0 +1,18 @@
+export const ADMIN_CUSTOM_ANALYSIS_OPEN = "ADMIN_CUSTOM_ANALYSIS_OPEN";
+export const adminCustomAnalysisOpen = isAdmin => ({
+  type: ADMIN_CUSTOM_ANALYSIS_OPEN,
+  isAdmin
+});
+
+export const ADMIN_STATUS_LOADED = "ADMIN_STATUS_LOADED";
+export const adminStatusLoaded = isAdmin => ({
+  type: ADMIN_STATUS_LOADED,
+  isAdmin
+});
+
+export const ADMIN_STATUS_ERROR = "ADMIN_STATUS_ERROR";
+export const adminStatusError = (isAdmin, error) => ({
+  type: ADMIN_STATUS_ERROR,
+  isAdmin,
+  error
+});

--- a/src/containers/AdminCustomAnalysis/actions.js
+++ b/src/containers/AdminCustomAnalysis/actions.js
@@ -16,3 +16,59 @@ export const adminStatusError = (isAdmin, error) => ({
   isAdmin,
   error
 });
+
+export const ADD_ADMIN_CUSTOM_ANALYSIS_REQUEST =
+  "ADD_ADMIN_CUSTOM_ANALYSIS_REQUEST";
+export const addAdminCustomAnalysisRequest = (
+  customAnalysisUrl,
+  customAnalysisName
+) => ({
+  type: ADD_ADMIN_CUSTOM_ANALYSIS_REQUEST,
+  customAnalysisUrl,
+  customAnalysisName
+});
+
+export const ADD_ADMIN_CUSTOM_ANALYSIS_SUCCESS =
+  "ADD_ADMIN_CUSTOM_ANALYSIS_SUCCESS";
+export const addAdminCustomAnalysisSuccess = (
+  customAnalysisUrl,
+  customAnalysisName
+) => ({
+  type: ADD_ADMIN_CUSTOM_ANALYSIS_SUCCESS,
+  customAnalysisUrl,
+  customAnalysisName
+});
+
+export const ADD_ADMIN_CUSTOM_ANALYSIS_FAIL = "ADD_ADMIN_CUSTOM_ANALYSIS_FAIL";
+export const addAdminCustomAnalysisFail = (
+  customAnalysisUrl,
+  customAnalysisName,
+  error
+) => ({
+  type: ADD_ADMIN_CUSTOM_ANALYSIS_FAIL,
+  customAnalysisUrl,
+  customAnalysisName,
+  error
+});
+
+export const DELETE_ADMIN_CUSTOM_ANALYSIS_REQUEST =
+  "DELETE_ADMIN_CUSTOM_ANALYSIS_REQUEST";
+export const deleteAdminCustomAnalysisRequest = customAnalysisID => ({
+  type: DELETE_ADMIN_CUSTOM_ANALYSIS_REQUEST,
+  customAnalysisID
+});
+
+export const DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS =
+  "DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS";
+export const deleteAdminCustomAnalysisSuccess = customAnalysisID => ({
+  type: DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS,
+  customAnalysisID
+});
+
+export const DELETE_ADMIN_CUSTOM_ANALYSIS_FAIL =
+  "DELETE_ADMIN_CUSTOM_ANALYSIS_FAIL";
+export const deleteAdminCustomAnalysisFail = (customAnalysisID, error) => ({
+  type: DELETE_ADMIN_CUSTOM_ANALYSIS_FAIL,
+  customAnalysisID,
+  error
+});

--- a/src/containers/AdminCustomAnalysis/actions.js
+++ b/src/containers/AdminCustomAnalysis/actions.js
@@ -72,3 +72,30 @@ export const deleteAdminCustomAnalysisFail = (customAnalysisID, error) => ({
   customAnalysisID,
   error
 });
+
+export const ADMIN_ANALYSE_REQUEST = "ADMIN_ANALYSE_REQUEST";
+export const adminAnalyseRequest = (adminAnalysisID, query) => ({
+  type: ADMIN_ANALYSE_REQUEST,
+  adminAnalysisID,
+  query
+});
+
+export const ADMIN_ANALYSE_SUCCESS = "ADMIN_ANALYSE_SUCCESS";
+export const adminAnalyseSuccess = (
+  adminAnalysisID,
+  query,
+  analysisResponse
+) => ({
+  type: ADMIN_ANALYSE_SUCCESS,
+  adminAnalysisID,
+  query,
+  analysisResponse
+});
+
+export const ADMIN_ANALYSE_FAIL = "ADMIN_ANALYSE_FAIL";
+export const adminAnalyseFail = (adminAnalysisID, query, error) => ({
+  type: ADMIN_ANALYSE_FAIL,
+  adminAnalysisID,
+  query,
+  error
+});

--- a/src/containers/AdminCustomAnalysis/reducer.js
+++ b/src/containers/AdminCustomAnalysis/reducer.js
@@ -1,0 +1,28 @@
+import { ADMIN_STATUS_LOADED, ADMIN_STATUS_ERROR } from "./actions";
+
+export const adminCustomAnalysis = (
+  state = {
+    dialog: "",
+    isAdmin: false,
+    error: ""
+  },
+  action
+) => {
+  switch (action.type) {
+    case ADMIN_STATUS_LOADED:
+      return {
+        ...state,
+        dialog: "ADMIN_CUSTOM_ANALYSIS_OPEN",
+        isAdmin: action.isAdmin
+      };
+    case ADMIN_STATUS_ERROR:
+      return {
+        ...state,
+        dialog: "ADMIN_CUSTOM_ANALYSIS_OPEN",
+        isAdmin: action.isAdmin,
+        error: action.error
+      };
+    default:
+      return state;
+  }
+};

--- a/src/containers/AdminCustomAnalysis/reducer.js
+++ b/src/containers/AdminCustomAnalysis/reducer.js
@@ -2,7 +2,9 @@ import {
   ADMIN_STATUS_LOADED,
   ADMIN_STATUS_ERROR,
   ADD_ADMIN_CUSTOM_ANALYSIS_SUCCESS,
-  DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS
+  DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS,
+  ADMIN_ANALYSE_SUCCESS,
+  ADMIN_ANALYSE_FAIL
 } from "./actions";
 
 export const adminCustomAnalysis = (
@@ -13,7 +15,8 @@ export const adminCustomAnalysis = (
     newCustomAnalysis: {
       customAnalysisUrl: "",
       customAnalysisName: ""
-    }
+    },
+    analysisResponse: {}
   },
   action
 ) => {
@@ -44,6 +47,18 @@ export const adminCustomAnalysis = (
       return {
         ...state,
         dialog: "DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS"
+      };
+    case ADMIN_ANALYSE_SUCCESS:
+      return {
+        ...state,
+        dialog: "ADMIN_ANALYSE_SUCCESS",
+        analysisResponse: action.analysisResponse
+      };
+    case ADMIN_ANALYSE_FAIL:
+      return {
+        ...state,
+        dialog: "ADMIN_ANALYSE_FAIL",
+        error: action.error
       };
     default:
       return state;

--- a/src/containers/AdminCustomAnalysis/reducer.js
+++ b/src/containers/AdminCustomAnalysis/reducer.js
@@ -1,10 +1,19 @@
-import { ADMIN_STATUS_LOADED, ADMIN_STATUS_ERROR } from "./actions";
+import {
+  ADMIN_STATUS_LOADED,
+  ADMIN_STATUS_ERROR,
+  ADD_ADMIN_CUSTOM_ANALYSIS_SUCCESS,
+  DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS
+} from "./actions";
 
 export const adminCustomAnalysis = (
   state = {
     dialog: "",
     isAdmin: false,
-    error: ""
+    error: "",
+    newCustomAnalysis: {
+      customAnalysisUrl: "",
+      customAnalysisName: ""
+    }
   },
   action
 ) => {
@@ -21,6 +30,20 @@ export const adminCustomAnalysis = (
         dialog: "ADMIN_CUSTOM_ANALYSIS_OPEN",
         isAdmin: action.isAdmin,
         error: action.error
+      };
+    case ADD_ADMIN_CUSTOM_ANALYSIS_SUCCESS:
+      return {
+        ...state,
+        dialog: "ADD_ADMIN_CUSTOM_ANALYSIS_SUCCESS",
+        newCustomAnalysis: {
+          customAnalysisUrl: action.customAnalysisUrl,
+          customAnalysisName: action.customAnalysisName
+        }
+      };
+    case DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS:
+      return {
+        ...state,
+        dialog: "DELETE_ADMIN_CUSTOM_ANALYSIS_SUCCESS"
       };
     default:
       return state;

--- a/src/containers/AdminCustomAnalysis/sagas.js
+++ b/src/containers/AdminCustomAnalysis/sagas.js
@@ -1,10 +1,17 @@
 import { call, put, take, select, takeLatest } from "redux-saga/effects";
 import {
   ADMIN_CUSTOM_ANALYSIS_OPEN,
+  ADD_ADMIN_CUSTOM_ANALYSIS_REQUEST,
+  DELETE_ADMIN_CUSTOM_ANALYSIS_REQUEST,
   adminStatusLoaded,
-  adminStatusError
+  adminStatusError,
+  addAdminCustomAnalysisSuccess,
+  addAdminCustomAnalysisFail,
+  deleteAdminCustomAnalysisSuccess,
+  deleteAdminCustomAnalysisFail
 } from "./actions";
 import { adminCustomAnalysisService } from "../../services/adminCustomAnalysis";
+import { notificationShow } from "../Root/actions";
 
 export function* adminCustomAnalysisOpenHandler() {
   try {
@@ -28,11 +35,69 @@ export function* adminCustomAnalysisOpenHandler() {
   }
 }
 
+export function* addAdminCustomAnalysisHandler(action) {
+  try {
+    let uid = yield select(state => state.firebase.auth.uid);
+    if (!uid) {
+      yield take("@@reactReduxFirebase/LOGIN");
+      uid = yield select(state => state.firebase.auth.uid);
+    }
+    yield call(
+      adminCustomAnalysisService.addAdminCustomAnalysis,
+      uid,
+      action.customAnalysisUrl,
+      action.customAnalysisName
+    );
+    yield put(
+      addAdminCustomAnalysisSuccess(
+        action.customAnalysisUrl,
+        action.customAnalysisName
+      )
+    );
+  } catch (err) {
+    yield put(
+      addAdminCustomAnalysisFail(
+        action.customAnalysisUrl,
+        action.customAnalysisName,
+        err.message
+      )
+    );
+    yield put(notificationShow(err.message));
+  }
+}
+
+export function* deleteAdminCustomAnalysisHandler(action) {
+  try {
+    yield call(
+      adminCustomAnalysisService.deleteAdminCustomAnalysis,
+      action.customAnalysisID
+    );
+    yield put(deleteAdminCustomAnalysisSuccess(action.customAnalysisID));
+  } catch (err) {
+    yield put(
+      deleteAdminCustomAnalysisFail(action.customAnalysisID, err.message)
+    );
+    yield put(notificationShow(err.message));
+  }
+}
+
 export default [
   function* watchAdminCustomAnalysisOpen() {
     yield takeLatest(
       ADMIN_CUSTOM_ANALYSIS_OPEN,
       adminCustomAnalysisOpenHandler
+    );
+  },
+  function* watchAddCustomAnalysis() {
+    yield takeLatest(
+      ADD_ADMIN_CUSTOM_ANALYSIS_REQUEST,
+      addAdminCustomAnalysisHandler
+    );
+  },
+  function* watchDeleteCustomAnalysis() {
+    yield takeLatest(
+      DELETE_ADMIN_CUSTOM_ANALYSIS_REQUEST,
+      deleteAdminCustomAnalysisHandler
     );
   }
 ];

--- a/src/containers/AdminCustomAnalysis/sagas.js
+++ b/src/containers/AdminCustomAnalysis/sagas.js
@@ -3,12 +3,15 @@ import {
   ADMIN_CUSTOM_ANALYSIS_OPEN,
   ADD_ADMIN_CUSTOM_ANALYSIS_REQUEST,
   DELETE_ADMIN_CUSTOM_ANALYSIS_REQUEST,
+  ADMIN_ANALYSE_REQUEST,
   adminStatusLoaded,
   adminStatusError,
   addAdminCustomAnalysisSuccess,
   addAdminCustomAnalysisFail,
   deleteAdminCustomAnalysisSuccess,
-  deleteAdminCustomAnalysisFail
+  deleteAdminCustomAnalysisFail,
+  adminAnalyseSuccess,
+  adminAnalyseFail
 } from "./actions";
 import { adminCustomAnalysisService } from "../../services/adminCustomAnalysis";
 import { notificationShow } from "../Root/actions";
@@ -81,6 +84,28 @@ export function* deleteAdminCustomAnalysisHandler(action) {
   }
 }
 
+export function* onAdminAnalyseHandler(action) {
+  try {
+    let analysisResponse = yield call(
+      adminCustomAnalysisService.onAdminAnalyse,
+      action.adminAnalysisID,
+      action.query
+    );
+    yield put(
+      adminAnalyseSuccess(
+        action.adminAnalysisID,
+        action.query,
+        analysisResponse
+      )
+    );
+  } catch (err) {
+    yield put(
+      adminAnalyseFail(action.adminAnalysisID, action.query, err.message)
+    );
+    yield put(notificationShow(err.message));
+  }
+}
+
 export default [
   function* watchAdminCustomAnalysisOpen() {
     yield takeLatest(
@@ -99,5 +124,8 @@ export default [
       DELETE_ADMIN_CUSTOM_ANALYSIS_REQUEST,
       deleteAdminCustomAnalysisHandler
     );
+  },
+  function* watchDeleteCustomAnalysis() {
+    yield takeLatest(ADMIN_ANALYSE_REQUEST, onAdminAnalyseHandler);
   }
 ];

--- a/src/containers/AdminCustomAnalysis/sagas.js
+++ b/src/containers/AdminCustomAnalysis/sagas.js
@@ -1,0 +1,38 @@
+import { call, put, take, select, takeLatest } from "redux-saga/effects";
+import {
+  ADMIN_CUSTOM_ANALYSIS_OPEN,
+  adminStatusLoaded,
+  adminStatusError
+} from "./actions";
+import { adminCustomAnalysisService } from "../../services/adminCustomAnalysis";
+
+export function* adminCustomAnalysisOpenHandler() {
+  try {
+    let uid = yield select(state => state.firebase.auth.uid);
+    if (!uid) {
+      yield take("@@reactReduxFirebase/LOGIN");
+      uid = yield select(state => state.firebase.auth.uid);
+    }
+    if (uid) {
+      const adminStatusResponse = yield call(
+        adminCustomAnalysisService.checkAdminStatus,
+        uid
+      );
+      const adminStatus = adminStatusResponse ? adminStatusResponse : false;
+      yield put(adminStatusLoaded(adminStatus));
+    } else {
+      yield put(adminStatusLoaded(false));
+    }
+  } catch (err) {
+    adminStatusError(false, err.message);
+  }
+}
+
+export default [
+  function* watchAdminCustomAnalysisOpen() {
+    yield takeLatest(
+      ADMIN_CUSTOM_ANALYSIS_OPEN,
+      adminCustomAnalysisOpenHandler
+    );
+  }
+];

--- a/src/containers/AdminCustomAnalysis/sagas.js
+++ b/src/containers/AdminCustomAnalysis/sagas.js
@@ -86,8 +86,14 @@ export function* deleteAdminCustomAnalysisHandler(action) {
 
 export function* onAdminAnalyseHandler(action) {
   try {
+    let uid = yield select(state => state.firebase.auth.uid);
+    if (!uid) {
+      yield take("@@reactReduxFirebase/LOGIN");
+      uid = yield select(state => state.firebase.auth.uid);
+    }
     let analysisResponse = yield call(
       adminCustomAnalysisService.onAdminAnalyse,
+      uid,
       action.adminAnalysisID,
       action.query
     );

--- a/src/containers/AppFrame/AppFrame.js
+++ b/src/containers/AppFrame/AppFrame.js
@@ -42,6 +42,7 @@ import Tasks from "../Tasks/Tasks";
 import CustomActivity from "../CustomActivity/CustomActivity";
 import Journeys from "../Journeys/Journeys";
 import CustomAnalysis from "../CustomAnalysis/CustomAnalysis";
+import AdminCustomAnalysis from "../AdminCustomAnalysis/AdminCustomAnalysis";
 
 // from Material-UI
 import AppBar from "@material-ui/core/AppBar";
@@ -383,6 +384,11 @@ class AppFrame extends React.Component {
                   component={CustomAnalysis}
                   exact
                   path="/customAnalysis"
+                />
+                <Route
+                  component={AdminCustomAnalysis}
+                  exact
+                  path="/adminCustomAnalysis"
                 />
                 <Route component={MockJourneys} exact path="/mock-journeys" />
                 <Route

--- a/src/containers/CustomAnalysis/CustomAnalysis.js
+++ b/src/containers/CustomAnalysis/CustomAnalysis.js
@@ -201,17 +201,32 @@ class CustomAnalysis extends React.PureComponent {
       let results = analysisResults.results
         ? analysisResults.results
         : analysisResults.result;
-      let data = {
-        response: {
-          data: {
-            isComplete: results.isComplete,
-            jsonFeedback: results.jsonFeedback,
-            htmlFeedback: results.htmlFeedback,
-            textFeedback: results.textFeedback,
-            ipynbFeedback: analysisResults.ipynb
+      let data;
+      if (!results) {
+        data = {
+          response: {
+            data: {
+              isComplete: false,
+              jsonFeedback: "",
+              htmlFeedback: "Please write into results.json file",
+              textFeedback: "",
+              ipynbFeedback: analysisResults.ipynb
+            }
           }
-        }
-      };
+        };
+      } else {
+        data = {
+          response: {
+            data: {
+              isComplete: results.isComplete,
+              jsonFeedback: results.jsonFeedback,
+              htmlFeedback: results.htmlFeedback,
+              textFeedback: results.textFeedback,
+              ipynbFeedback: analysisResults.ipynb
+            }
+          }
+        };
+      }
       return data;
     } else if (dialog === ANALYSE_FAIL && analysisResults) {
       return {

--- a/src/containers/CustomAnalysis/CustomAnalysis.js
+++ b/src/containers/CustomAnalysis/CustomAnalysis.js
@@ -67,26 +67,10 @@ const styles = theme => ({
   }
 });
 
-/**
- * Things to do -
- * 1. [DONE] Iterate through the options you've created
- * 2. Disable options
- * 3. Clear to clear all fields
- * 4. [VERIFY] Handle empty cases
- * 5. [DONE] Store analysis data from dialog
- * 6. [DONE] Update activities/assignments when path/course option changes
- * 7. Reset state and clear fields when someone toggles between path and course
- * 8. [DONE] Change custom activity to expect json as jsonFeedback and then change your lambda
- * 9. Read the analyse chart from firestore and display as last updated at
- * 10. [DONE] Pass dummy solutions and display analysis
- * 11. [DONE] Display ipnb feedback
- * 12. [DONE] Move the service function to firebase functions
- */
-
 class CustomAnalysis extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object,
-    addCustomActivity: PropTypes.func,
+    addCustomAnalysis: PropTypes.func,
     deleteCustomAnalysis: PropTypes.func,
     onAnalyse: PropTypes.func,
     onOpen: PropTypes.func,
@@ -127,7 +111,7 @@ class CustomAnalysis extends React.PureComponent {
   }
 
   listHandler(listType, listValue) {
-    let data;
+    let data = {};
     switch (listType) {
       case "Type":
         data =
@@ -165,7 +149,7 @@ class CustomAnalysis extends React.PureComponent {
   }
 
   addCustomAnalysisHandler(url, name) {
-    this.props.addCustomActivity(url, name);
+    this.props.addCustomAnalysis(url, name);
   }
 
   deleteCustomAnalysisHandler(analysisID) {
@@ -469,7 +453,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   onOpen: customAnalysisOpen,
-  addCustomActivity: addCustomAnalysisRequest,
+  addCustomAnalysis: addCustomAnalysisRequest,
   deleteCustomAnalysis: deleteCustomAnalysisRequest,
   onAnalyse: analyseRequest
 };

--- a/src/services/adminCustomAnalysis.js
+++ b/src/services/adminCustomAnalysis.js
@@ -134,5 +134,17 @@ export class AdminCustomAnalysisService {
       .doc(customAnalysisID)
       .delete();
   }
+
+  /**
+   * This method removes the custom activity of the given
+   * custom analysis id and user id
+   *
+   * @param {String} adminCustomAnalysisID customAnalysis ID to be deleted
+   * @param {String} query queries to be executed to fetch data from the database
+   *
+   */
+  onAdminAnalyse(adminCustomAnalysisID, query) {
+    return { response: "Dummy Response" };
+  }
 }
 export const adminCustomAnalysisService = new AdminCustomAnalysisService();

--- a/src/services/adminCustomAnalysis.js
+++ b/src/services/adminCustomAnalysis.js
@@ -1,4 +1,9 @@
 import firebase from "firebase/app";
+import "firebase/firestore";
+
+import { SOLUTION_PRIVATE_LINK } from "../containers/Root/actions";
+
+const NOT_FOUND_ERROR = 404;
 
 export class AdminCustomAnalysisService {
   /**
@@ -16,6 +21,118 @@ export class AdminCustomAnalysisService {
       .ref(`/admins/${uid}`)
       .once("value")
       .then(response => response.val());
+  }
+
+  constructor() {
+    this.addAdminCustomAnalysis = this.addAdminCustomAnalysis.bind(this);
+  }
+  auth() {
+    return new Promise(resolve =>
+      window.gapi.load("client:auth2", () => {
+        window.gapi.client
+          .init({
+            apiKey: "AIzaSyC27mcZBSKrWavXNhsDA1HJCeUurPluc1E",
+            clientId:
+              "765594031611-aitdj645mls974mu5oo7h7m27bh50prc.apps." +
+              "googleusercontent.com",
+            discoveryDocs: [
+              "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"
+            ]
+          })
+          .then(resolve);
+      })
+    );
+  }
+
+  /**
+   * This method takes in the file id from the url and returns
+   * notebook contents for the passed in fileID.
+   *
+   * @param {String} fileID file id from the Custom Analysis url
+   *
+   * @returns {Object} Object containing notebook contents
+   */
+
+  fetchFile(fileId) {
+    const request = window.gapi.client.drive.files.get({
+      fileId,
+      alt: "media"
+    });
+    return new Promise((resolve, reject) =>
+      request.execute(data => {
+        if (data.code && data.code === NOT_FOUND_ERROR) {
+          return reject(new Error(SOLUTION_PRIVATE_LINK));
+        }
+        resolve({
+          ...data,
+          cells: (data.cells || []).filter(d =>
+            d.source.join("").replace(/\n/g, "")
+          ),
+          result: {
+            ...data.result,
+            cells: data.result.cells.filter(
+              d => d.source.join("").replace(/\n/g, "").length > 0
+            )
+          }
+        });
+      })
+    );
+  }
+
+  /**
+   * This method adds custom analysis details to firestore.
+   * URL stored can be of two types -
+   * 1. Colaboratory URL :
+   *    Custom Analysis type : "jupyter"
+   *    Notebook contents stored along with other details.
+   * 2. Cloud Function :
+   *    Custom Analysis type : "cloudFunction"
+   *
+   * @param {String} uid user id of creator
+   * @param {String} customAnalysisUrl Colab URL/ Cloud Function url for analysis
+   * @param {String} customAnalysisName Custom Analysis name
+   *
+   */
+  async addAdminCustomAnalysis(uid, customAnalysisUrl, customAnalysisName) {
+    let storeData = {};
+    let result = /https:\/\/colab.research.google.com\/drive\/([^/&?#]+)/.exec(
+      customAnalysisUrl
+    );
+    if (result && result[1]) {
+      // Colaboratory link. Fetch notebook contents
+      let fileID = result[1];
+      let data = await this.fetchFile(fileID);
+      storeData = { analysisNotebook: JSON.stringify(data), type: "jupyter" };
+    } else {
+      // Cloud function. No notebook contents to fetch.
+      storeData = { type: "cloudFunction" };
+    }
+    return await firebase
+      .firestore()
+      .collection("/adminCustomAnalysis")
+      .add({
+        createdAt: firebase.firestore.Timestamp.now().toMillis(),
+        uid: uid,
+        name: customAnalysisName,
+        url: customAnalysisUrl,
+        ...storeData
+      });
+  }
+
+  /**
+   * This method removes the custom activity of the given
+   * custom analysis id and user id
+   *
+   * @param {String} uid user id of creator
+   * @param {String} customAnalysisID customAnalysis ID to be deleted
+   *
+   */
+  async deleteAdminCustomAnalysis(customAnalysisID) {
+    await firebase
+      .firestore()
+      .collection("/adminCustomAnalysis")
+      .doc(customAnalysisID)
+      .delete();
   }
 }
 export const adminCustomAnalysisService = new AdminCustomAnalysisService();

--- a/src/services/adminCustomAnalysis.js
+++ b/src/services/adminCustomAnalysis.js
@@ -1,0 +1,21 @@
+import firebase from "firebase/app";
+
+export class AdminCustomAnalysisService {
+  /**
+   * This method returns true or false based on whether the given user
+   * is an admin or not
+   *
+   * @param {String} uid user id of creator
+   *
+   * @returns {Boolean} returns true or false
+   */
+
+  async checkAdminStatus(uid) {
+    return await firebase
+      .database()
+      .ref(`/admins/${uid}`)
+      .once("value")
+      .then(response => response.val());
+  }
+}
+export const adminCustomAnalysisService = new AdminCustomAnalysisService();

--- a/src/services/adminCustomAnalysis.js
+++ b/src/services/adminCustomAnalysis.js
@@ -147,13 +147,6 @@ export class AdminCustomAnalysisService {
       });
   }
 
-  enquote(v) {
-    if (typeof v === "string") {
-      return '"' + v + '"';
-    }
-    return v;
-  }
-
   async buildFirebaseQuery(firebaseQueries) {
     try {
       let firebaseQuery;
@@ -166,9 +159,7 @@ export class AdminCustomAnalysisService {
 
         for (let option of Object.keys(oneQuery.query.firebase)) {
           if (option !== "ref") {
-            let value = oneQuery.query.firebase[option]
-              ? this.enquote(oneQuery.query.firebase[option])
-              : null;
+            let value = oneQuery.query.firebase[option] || null;
             if (value) {
               firebaseQuery = firebaseQuery[option](value);
             }
@@ -178,8 +169,8 @@ export class AdminCustomAnalysisService {
         firebaseResults.push({
           [oneQuery.name]: tempResults
         });
-        return firebaseResults;
       }
+      return firebaseResults;
     } catch (error) {
       console.error(error.message);
     }

--- a/src/services/customAnalysis.js
+++ b/src/services/customAnalysis.js
@@ -240,7 +240,7 @@ export class CustomAnalysisService {
    * This method stores the Custom Analysis response
    *
    * @param {String} uid user id of creator
-   * @param {String} response collection of user solutions to be analysed
+   * @param {String} response Analysis Response
    * @param {String} analysisID Custom Analysis ID
    *
    */
@@ -278,7 +278,8 @@ export class CustomAnalysisService {
       .httpsCallable("runCustomAnalysis")({
         uid,
         solutions,
-        analysisID
+        analysisID,
+        analysisType: "customAnalysis"
       })
       .then(response => this.storeAnalysis(uid, response, analysisID))
       .catch(err => console.error(err));


### PR DESCRIPTION
#916 : Added various options to query firebase database for admins. 
An admin can submit a colaboratory notebook/ lambda function as a custom analysis and form firebase queries with the help of a given query builder. The query results are bundled up and sent to the analysis notebook/function. The received response is displayed with formatted html,json,text and ipynb feedback. The admin can only perform read/fetch operation on the database.

This can currently be accessed via /adminCustomAnalysis hidden route.
